### PR TITLE
Simpler infinite loop fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,31 +20,6 @@ export type Instances<Si> = {
   arr: Array<Si & {_key: string}>,
 };
 
-function onionifyChild(childComp: any): any {
-  return function childOnionified(sources: any): any {
-    const reducerMimic$ = xs.create<Reducer<any>>();
-
-    const stateFromParent$ = sources.onion.state$;
-    const stateFromChild$: Stream<any> = stateFromParent$
-      .map((stateFromParent: any) =>
-        reducerMimic$.fold((state, reducer) => reducer(state), stateFromParent).drop(1)
-      ).flatten().remember();
-
-    const state$ = xs.merge(stateFromParent$, stateFromChild$).remember()
-    sources.onion = new StateSource<any>(state$, 'onion') as any;
-    const sinks = childComp(sources);
-    if (sinks.onion) {
-      const stream$ = xs.fromObservable<Reducer<any>>(sinks.onion);
-      reducerMimic$.imitate(stream$);
-
-      const reducerToParent$ = stateFromChild$.map((state: any) => () => state);
-      return {...sinks, onion: reducerToParent$};
-    } else {
-      return sinks;
-    }
-  };
-}
-
 function defaultGetKey(statePiece: any) {
   return statePiece.key;
 }
@@ -100,7 +75,7 @@ export function collection<Si>(itemComp: (so: any) => Si,
         nextInstArray[i] = dict.get(key) as any;
       } else {
         const scopes = {'*': '$' + key, onion: instanceLens(getKey, key)};
-        const sinks = isolate(onionifyChild(itemComp), scopes)(sources);
+        const sinks = isolate(itemComp, scopes)(sources);
         dict.set(key, sinks);
         nextInstArray[i] = sinks;
       }


### PR DESCRIPTION
Cheers! I notice that you've been solving the infinite loop issue from `cycle-onionify` as well. I think there might be even simpler solution: remove the redundant "imitate layer" and instead of emitting reducers from every state change, react to the actual child reducer stream and let the `instanceLens` handle the rest.

I tested it with the examples and didn't find any complications -- max call stack exception is gone as well (even though you're not preserving item identities in the parent lens). Could you check whether this solution works in your case or not? 😊  